### PR TITLE
 misc: Add message that the project is no longer maintained 

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,11 +1,12 @@
+**This project is deprecated and is no longer maintained. It will not work with
+the latest version of Cirq.**
+
 # Q-CTRL Python Cirq
 
 The aim of the Q-CTRL Cirq Adapter package is to provide export functions allowing
 users to deploy established error-robust quantum control protocols from the
 open literature and defined in Q-CTRL Open Controls on Google quantum devices
 and simulators.
-
-Anyone interested in quantum control is welcome to contribute to this project.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+**This project is deprecated and is no longer maintained. It will not work with
+the latest version of Cirq.**
+
 # Q-CTRL Python Cirq
 
 The aim of the Q-CTRL Cirq Adapter package is to provide export functions allowing
 users to deploy established error-robust quantum control protocols from the
 open literature and defined in Q-CTRL Open Controls on Google quantum devices
 and simulators.
-
-Anyone interested in quantum control is welcome to contribute to this project.

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,7 @@
 
+**This project is deprecated and is no longer maintained. It will not work with
+the latest version of Cirq.**
+
 Q-CTRL Python Cirq
 ==================
 
@@ -6,5 +9,3 @@ The aim of the Q-CTRL Cirq Adapter package is to provide export functions allowi
 users to deploy established error-robust quantum control protocols from the
 open literature and defined in Q-CTRL Open Controls on Google quantum devices
 and simulators.
-
-Anyone interested in quantum control is welcome to contribute to this project.


### PR DESCRIPTION
The example notebook for this package doesn't run with the latest version of Cirq (0.13.1) because this package hasn't been maintained. This pull request makes this fact explicit in the READMEs.

Changes proposed in this pull request:
- Add deprecation warning to the README files.